### PR TITLE
Changes to entrez plugin for 2.0 esummaries

### DIFF
--- a/R/plugins_search.R
+++ b/R/plugins_search.R
@@ -62,10 +62,10 @@ plugin_entrez <- function(sources, query, limit, opts){
       }), stringsAsFactors=FALSE)
     })
     data <- do.call(rbind.fill, dat)
-    data <- move_col(data, "Title")
-    data <- move_col(data, "AuthorList")
+    data <- move_col(data, "title")
+    data <- move_col(data, "authors")
     
-    zz <- list(found = out$count, data = data, opts = opts)
+    zz <- list(found = as.integer(out$count), data = data, opts = opts)
     structure(zz, class="ft_ind", query=query)
   } else {
     zz <- list(found = NULL, data = NULL, opts = opts)

--- a/R/plugins_search.R
+++ b/R/plugins_search.R
@@ -55,13 +55,15 @@ plugin_entrez <- function(sources, query, limit, opts){
     out <- do.call(entrez_search, opts)
     sumres <- entrez_summary(db = "pmc", id=out$ids)
     dat <- lapply(sumres, function(x){
-      x$file <- NULL
-      data.frame(lapply(x, function(z){
-        tmp <- if(length(z) > 1) paste(z, collapse=", ") else z
-        if(is.null(tmp)) NA else tmp
-      }), stringsAsFactors=FALSE)
-    })
-    data <- do.call(rbind.fill, dat)
+      x$authors <- paste(x$authors[,1], collapse=", ")
+      x$pmid  <- x$articleids[x$articleids[,1] == "pmid", 2]
+      x$doi   <- x$articleids[x$articleids[,1] == "doi",  2]
+      x$pmcid <- x$articleids[x$articleids[,1] == "pmcid",2]
+      x$mid   <- x$articleids[x$articleids[,1] == "MID",  2]
+      x$articleids <- NULL
+      lapply(x, function(z) if(is.null(z) | length(z) == 0) NA else z)
+      })
+    data <- plyr::ldply(dat, data.frame,stringsAsFactors=FALSE, .id="uid" )
     data <- move_col(data, "title")
     data <- move_col(data, "authors")
     


### PR DESCRIPTION
Hi Scott, 
 I'm working on a new CRAN release for rentrez (ropensci/rentrez#25), which should go up in the next couple of days. 

As discussed in #17  the new version  will pull down "version 2.0"
esummary records, which contain slightly different information than
older forms, the change was enough to break the entrez plugin for fulltext.

This commit aligns the existing plugin with the default behavior in rentrez -- it works for the examples I could find. The other option is to add

```r
opts$version <- "1.0"
```

to the plugin, which will retrieve the "old" records.