### PR TITLE
Added DataDRYAD support

### DIFF
--- a/R/ft_get_si_plugins.R
+++ b/R/ft_get_si_plugins.R
@@ -4,7 +4,9 @@ get_si_pub <- function(x){
 
     #Doing the check here saves one internet call
     if(grepl("figshare", x))
-            return("figshare")
+        return("figshare")
+    if(grepl("dryad", x))
+        return("dryad")
     pub <- cr_works(x)$data
     
     if(pub$prefix=="http://id.crossref.org/prefix/10.0000")
@@ -35,7 +37,8 @@ get_si_func <- function(x) {
                      "esa_data_archives" = get_si_esa_data_archives,
                      "esa_archives" = get_si_esa_archives,
                      "biorxiv" = get_si_biorxiv,
-                     "epmc" = get_si_epmc
+                     "epmc" = get_si_epmc,
+                     "dryad" = get_si_dryad
                      )
     #If all else fails, try EPMC
     if(is.null(output))
@@ -194,4 +197,17 @@ get_si_biorxiv <- function(doi, si, save.name=NA, dir=NA, cache=TRUE, ...){
     url <- paste0(.url.redir(paste0("http://dx.doi.org/", doi)), ".figures-only")
     file <- .grep.url(url, "/highwire/filestream/[a-z0-9A-Z\\./_-]*", si)
     return(.download(.url.redir(paste0("http://biorxiv.org",file)), dir, save.name, cache))
+}
+
+get_si_dryad <- function(doi, si, save.name=NA, dir=NA, cache=TRUE, ...){
+    #Argument handling
+    if(!is.character(si))
+        stop("DataDRYAD download requires numeric SI info")
+    dir <- .tmpdir(dir)
+    save.name <- .save.name(doi, save.name, si)
+    
+    #Find, download, and return
+    url <- .url.redir(paste0("http://dx.doi.org/", doi))
+    file <- .grep.url(url, paste0("/bitstream/handle/[0-9]+/dryad\\.[0-9]+/", si))
+    return(.download(.url.redir(paste0("http://datadryad.org",file)), dir, save.name, cache))
 }

--- a/R/ft_get_si_plugins.R
+++ b/R/ft_get_si_plugins.R
@@ -208,6 +208,6 @@ get_si_dryad <- function(doi, si, save.name=NA, dir=NA, cache=TRUE, ...){
     
     #Find, download, and return
     url <- .url.redir(paste0("http://dx.doi.org/", doi))
-    file <- .grep.url(url, paste0("/bitstream/handle/[0-9]+/dryad\\.[0-9]+/", si))
+    file <- .grep.url(url, paste0("/bitstream/handle/[0-9]+/dryad\\.[0-9]+/", URLencode(si,reserved=TRUE)))
     return(.download(.url.redir(paste0("http://datadryad.org",file)), dir, save.name, cache))
 }

--- a/tests/testthat/test-ft_get_si.r
+++ b/tests/testthat/test-ft_get_si.r
@@ -18,7 +18,7 @@ test_that("ft_get_si returns...", {
   expect_true(file.exists(ft_get_si("10.1101/016386", 1)))
   expect_true(file.exists(ft_get_si("10.1371/journal.pone.0126524", "pone.0126524.g005.jpg", "epmc")))
   expect_true(file.exists(ft_get_si("10.5061/dryad.34m6j", "datafile.csv")))
-
+  
   #Extra checks for Wiley
   expect_true(file.exists(ft_get_si("10.1111/ele.12437", si=1)))
   expect_true(file.exists(ft_get_si("10.1111/ele.12437", si=2)))

--- a/tests/testthat/test-ft_get_si.r
+++ b/tests/testthat/test-ft_get_si.r
@@ -17,6 +17,7 @@ test_that("ft_get_si returns...", {
   expect_true(file.exists(ft_get_si("10.1098/rspb.2015.0338", vol=282, issue=1811, 1)))
   expect_true(file.exists(ft_get_si("10.1101/016386", 1)))
   expect_true(file.exists(ft_get_si("10.1371/journal.pone.0126524", "pone.0126524.g005.jpg", "epmc")))
+  expect_true(file.exists(ft_get_si("10.5061/dryad.34m6j", "datafile.csv")))
 
   #Extra checks for Wiley
   expect_true(file.exists(ft_get_si("10.1111/ele.12437", si=1)))

--- a/tests/testthat/test-ft_get_si.r
+++ b/tests/testthat/test-ft_get_si.r
@@ -17,7 +17,15 @@ test_that("ft_get_si returns...", {
   expect_true(file.exists(ft_get_si("10.1098/rspb.2015.0338", vol=282, issue=1811, 1)))
   expect_true(file.exists(ft_get_si("10.1101/016386", 1)))
   expect_true(file.exists(ft_get_si("10.1371/journal.pone.0126524", "pone.0126524.g005.jpg", "epmc")))
-  expect_true(file.exists(ft_get_si("10.5061/dryad.34m6j", "datafile.csv")))
+  
+  #DRYAD
+  expect_error(file <- ft_get_si("10.5061/dryad.34m6j", "datafile.csv"), NA)
+  expect_error(data <- read.csv(file), NA)
+  expect_equal(dim(data), c(145,49))
+  expect_error(file <- ft_get_si("10.5061/dryad.55610", "Data (revised).txt"), NA)
+  expect_error(data <- read.delim(file), NA)
+  expect_equal(dim(data), c(740,25))
+    
   
   #Extra checks for Wiley
   expect_true(file.exists(ft_get_si("10.1111/ele.12437", si=1)))


### PR DESCRIPTION
You can now download from dryad using `ft_get_si`. Includes a minimal test.

## Description
Very small change. Needs reserved URL encoding (a lot of dryad files use spaces, etc., in filenames)

## Related Issue
None.

## Example
data <- read.table(ft_get_si("10.5061/dryad.55610", "Data (revised).txt"), header=T, sep='\t')