### PR TITLE
fix tiny bug, closes #110

### DIFF
--- a/R/bio_utils.R
+++ b/R/bio_utils.R
@@ -29,7 +29,7 @@ biorxiv_search <- function(query, limit = 10, ...) {
     dois <- strtrim(strextract(
       xml2::xml_text(
         xml2::xml_find_all(
-          html, 
+          w, 
           '//div[@class="highwire-cite-metadata"]//span[@class="highwire-cite-metadata-doi highwire-cite-metadata"]')
       ),
       "https.+"


### PR DESCRIPTION
## Description
There as a small 🐛 that was causing the function to only search for the DOIs from the first page.

## Related Issue
fix #110