### PR TITLE
use preferred DOI resolver

### DIFF
--- a/R/ft_browse.R
+++ b/R/ft_browse.R
@@ -38,7 +38,7 @@ ft_browse <- function(x, what = "macrodocs", browse = TRUE) {
 }
 
 md <- function() "http://macrodocs.org/?doi="
-dx <- function() "http://dx.doi.org/"
+dx <- function() "https://doi.org/"
 
 get_doi <- function(x){
   tmp <- ft_compact(sapply(x, function(v){
@@ -101,7 +101,7 @@ template <-
             </h4>
           </div>
           <div id="collapseOne{{collapse}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne{{collapse}}">
-            <div class="panel-body"> <a href="http://dx.doi.org/{{doi}}" target="_blank" class="btn btn-info btn-xs" role="button"><i class="fa fa-link"></i></a> &nbsp;
+            <div class="panel-body"> <a href="https://doi.org/{{doi}}" target="_blank" class="btn btn-info btn-xs" role="button"><i class="fa fa-link"></i></a> &nbsp;
               {{target}}
             </div>
           </div>

--- a/R/ft_get_si_plugins.R
+++ b/R/ft_get_si_plugins.R
@@ -104,7 +104,7 @@ get_si_figshare <- function(doi, si, save.name=NA, dir=NA, cache=TRUE, ...){
     save.name <- .save.name(doi, save.name, si)
 
     #Find, download, and return
-    html <- read_html(httr::content(GET(paste0("http://dx.doi.org/", doi)), "text"))
+    html <- read_html(httr::content(GET(paste0("https://doi.org/", doi)), "text"))
     results <- fromJSON(xml_text(xml_find_first(html, "//script[@type=\"text/json\"]")))$article$files
     if (is.numeric(si)) {
       if (si > nrow(results)) {
@@ -193,7 +193,7 @@ get_si_biorxiv <- function(doi, si, save.name=NA, dir=NA, cache=TRUE, ...){
     save.name <- .save.name(doi, save.name, si)
 
     #Find, download, and return
-    url <- paste0(.url.redir(paste0("http://dx.doi.org/", doi)), ".figures-only")
+    url <- paste0(.url.redir(paste0("https://doi.org/", doi)), ".figures-only")
     file <- .grep.url(url, "/highwire/filestream/[a-z0-9A-Z\\./_-]*", si)
     return(.download(.url.redir(paste0("http://biorxiv.org",file)), dir, save.name, cache, ...))
 }

--- a/R/plugins_links.R
+++ b/R/plugins_links.R
@@ -66,7 +66,7 @@ bmc_link <- function(dois) {
   xmlbase <- "http://%s/content/download/xml/%s.xml"
   pdfbase <- "http://%s/content/pdf/%s.pdf"
   lapply(dois, function(x) {
-    res <- httr::HEAD(paste0("http://dx.doi.org/", x))
+    res <- httr::HEAD(paste0("https://doi.org/", x))
     url <- httr::parse_url(res$all_headers[[1]]$headers$location)$hostname
     x <- strsplit(x, "/")[[1]][2]
     list(xml = sprintf(xmlbase, url, x), pdf = sprintf(pdfbase, url, x))

--- a/tests/testthat/test-ft_browse.R
+++ b/tests/testthat/test-ft_browse.R
@@ -37,7 +37,7 @@ test_that("ft_browse returns...", {
   expect_match(aa, "eLife")
   expect_match(bb, "fphar")
   expect_match(cc, "eLife")
-  expect_equal(cc, "http://dx.doi.org/10.7554/eLife.04251")
+  expect_equal(cc, "https://doi.org/10.7554/eLife.04251")
   
   expect_match(xml_text(xml_children(xml_children(aa_txt)[[2]])[[1]]), "Macrodocs")
   


### PR DESCRIPTION
The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

## Description
Updates all dx.doi.org links accordingly. All tests that don't depend on an API key succeeded.
