### PR TITLE
Add Elsevier ScienceDirect API as full text provider

### DIFF
--- a/R/ft_get.R
+++ b/R/ft_get.R
@@ -382,8 +382,8 @@
 #' }
 
 ft_get <- function(x, from = NULL, type = "xml", try_unknown = TRUE, 
-  plosopts = list(), bmcopts = list(), entrezopts = list(), 
-  elifeopts = list(), elsevieropts = list(), wileyopts = list(), 
+  plosopts = list(), bmcopts = list(), entrezopts = list(), elifeopts = list(),
+  elsevieropts = list(), sciencedirectopts = list(), wileyopts = list(), 
   crossrefopts = list(), progress = FALSE, ...) {
 
   UseMethod("ft_get")
@@ -392,7 +392,7 @@ ft_get <- function(x, from = NULL, type = "xml", try_unknown = TRUE,
 #' @export
 ft_get.default <- function(x, from=NULL, type = "xml", try_unknown = TRUE,
   plosopts=list(), bmcopts=list(), entrezopts=list(), elifeopts=list(),
-  elsevieropts = list(), wileyopts = list(), crossrefopts = list(), 
+  elsevieropts = list(), sciencedirectopts = list(), wileyopts = list(), crossrefopts = list(), 
   progress = FALSE, ...) {
 
   stop("no 'ft_get' method for ", class(x), call. = FALSE)

--- a/R/fulltext-package.R
+++ b/R/fulltext-package.R
@@ -81,6 +81,20 @@
 #' this package. If you aren't physically at your institution you will likely 
 #' need to be on a VPN or similar so that your IP address is in the range 
 #' that the two publishers are accepting for that institution.
+#' 
+#' **ScienceDirect**: Elsevier ScienceDirect requires two things: an API key 
+#' and your institution must have access. For the API key, 
+#' go to https://dev.elsevier.com/index.html, 
+#' register for an account, then when you're in your account, create an API key 
+#' that is allowed to access the TDM API (must accept their TDM policy). 
+#' Pass in as variable `key` to `sciencedirectopts`, or store your key under the name 
+#' `ELSEVIER_TDM_KEY` as an environment variable in `.Renviron`, and 
+#' we'll read it in for you. See [Startup] for help. For the institution access
+#' go to a browser and see if you have access to the journal(s) you want. 
+#' If you don't have access in a browser you probably won't have access via 
+#' this package. If you aren't physically at your institution you will likely 
+#' need to be on a VPN or similar so that your IP address is in the range 
+#' that the publisher is accepting for that institution.
 #'  
 #' **Microsoft**: Get a key by creating an Azure account at 
 #' <https://www.microsoft.com/cognitive-services/en-us/subscriptions>, 
@@ -159,5 +173,6 @@
 #' @docType package
 #' @author Scott Chamberlain <myrmecocystus@@gmail.com>
 #' @author Will Pearse
+#' @author Helge Knüttel
 #' @keywords package
 NULL

--- a/R/plugins_get.R
+++ b/R/plugins_get.R
@@ -456,11 +456,12 @@ sciencedirect_ft <- function(dois, type, progress = FALSE, ...) {
     )
     
     # We specifically ask for the full text. Thus, we get an error if not available
-    # instead of silently just an abstract.
+    # instead of silently just an abstract or some other metadata.
     url <- paste0("https://api.elsevier.com/content/article/doi/", x, "?view=FULL")
     http <- crul::HttpClient$new(
       url = url,
-      headers = header
+      headers = header,
+      opts = list(...)
     )
     res <- tcat(http$head())
     if (inherits(res, c("error", "warning")) || !res$success()) {

--- a/R/plugins_get.R
+++ b/R/plugins_get.R
@@ -464,7 +464,17 @@ sciencedirect_ft <- function(dois, type, progress = FALSE, ...) {
     )
     res <- tcat(http$head())
     if (inherits(res, c("error", "warning")) || !res$success()) {
-      mssg <- if (inherits(res, c("error", "warning"))) res$message else http_mssg(res)
+      if (inherits(res, c("error", "warning"))) {
+        mssg <- res$message 
+      } else {
+        # Elsevier gives an extra message in case of errors
+        if (is.null(res$response_headers$`x-els-status`)) {
+          elsevier_status <- ""
+        } else {
+          elsevier_status <- paste(":", res$response_headers$`x-els-status`)
+        }
+        mssg <- paste0(http_mssg(res), elsevier_status)
+      }
       return(ft_error(mssg, x))
     }
     

--- a/man/ft_get.Rd
+++ b/man/ft_get.Rd
@@ -7,7 +7,8 @@
 \usage{
 ft_get(x, from = NULL, type = "xml", try_unknown = TRUE,
   plosopts = list(), bmcopts = list(), entrezopts = list(),
-  elifeopts = list(), elsevieropts = list(), wileyopts = list(),
+  elifeopts = list(), elsevieropts = list(),
+  sciencedirectopts = list(), wileyopts = list(),
   crossrefopts = list(), progress = FALSE, ...)
 
 ft_get_ls()
@@ -19,10 +20,10 @@ returned from \code{\link[=ft_search]{ft_search()}}}
 
 \item{from}{Source to query. Optional.}
 
-\item{type}{(character) one of xml (default), pdf, or plain (Elsevier only).
+\item{type}{(character) one of xml (default), pdf, or plain (Elsevier and ScienceDirect only).
 We choose to go with xml as the default as it has structure that a machine
 can reason about, but you are of course free to try to get xml, pdf, or plain
-(in the case of Elsevier).}
+(in the case of Elsevier and ScienceDirect).}
 
 \item{try_unknown}{(logical) if publisher plugin not already known, we try to
 fetch full text link either from ftdoi.org or from Crossref. If not found at
@@ -40,6 +41,8 @@ and \code{\link[=entrez_fetch]{entrez_fetch()}}}
 \item{elifeopts}{eLife options, a named list.}
 
 \item{elsevieropts}{Elsevier options, a named list.}
+
+\item{sciencedirectopts}{Elsevier ScienceDirect options, a named list.}
 
 \item{wileyopts}{Wiley options, a named list.}
 
@@ -129,6 +132,9 @@ is through the Crossref TDM flow in which you need a Crossref TDM API
 key and your institution needs to have access to the exact journal you
 are trying to fetch a paper from. If your institution doesn't have
 access you may still get a result, but likely its only the abstract.
+Pretty much the same is true when fetching from ScienceDirect directly.
+You need to have an Elsevier API key
+that is valid for their TDM/article API.
 See \strong{Authentication} in \link{fulltext-package} for details.
 }
 
@@ -144,6 +150,7 @@ they only accept one type. By data source/publisher:
 \item arXiv: only pdf
 \item BiorXiv: only pdf
 \item Elsevier: xml and plain
+\item Elsevier ScienceDirect: xml and plain
 \item Wiley: only pdf
 \item Peerj: pdf and xml
 \item Informa: only pdf
@@ -349,6 +356,10 @@ ft_get(res)
 # elsevier, ugh
 ## set an environment variable like Sys.setenv(CROSSREF_TDM = "your key")
 ft_get(x = "10.1016/j.trac.2016.01.027", from = "elsevier")
+
+# sciencedirect
+## set an environment variable like Sys.setenv(ELSEVIER_TDM_KEY = "your key")
+ft_get(x = "10.1016/S0140-6736(13)62329-6", from = "sciencedirect")
 
 # wiley, ugh
 ## Wiley has only PDF, so type parameter doesn't do anything

--- a/man/fulltext-package.Rd
+++ b/man/fulltext-package.Rd
@@ -100,6 +100,20 @@ this package. If you aren't physically at your institution you will likely
 need to be on a VPN or similar so that your IP address is in the range
 that the two publishers are accepting for that institution.
 
+\strong{ScienceDirect}: Elsevier ScienceDirect requires two things: an API key
+and your institution must have access. For the API key,
+go to https://dev.elsevier.com/index.html,
+register for an account, then when you're in your account, create an API key
+that is allowed to access the TDM API (must accept their TDM policy).
+Pass in as variable \code{key} to \code{sciencedirectopts}, or store your key under the name
+\code{ELSEVIER_TDM_KEY} as an environment variable in \code{.Renviron}, and
+we'll read it in for you. See \link{Startup} for help. For the institution access
+go to a browser and see if you have access to the journal(s) you want.
+If you don't have access in a browser you probably won't have access via
+this package. If you aren't physically at your institution you will likely
+need to be on a VPN or similar so that your IP address is in the range
+that the publisher is accepting for that institution.
+
 \strong{Microsoft}: Get a key by creating an Azure account at
 \url{https://www.microsoft.com/cognitive-services/en-us/subscriptions},
 then requesting a key for \strong{Academic Knowledge API} within
@@ -167,5 +181,7 @@ Let us know what you think at \url{https://github.com/ropensci/fulltext/issues}
 Scott Chamberlain \href{mailto:myrmecocystus@gmail.com}{myrmecocystus@gmail.com}
 
 Will Pearse
+
+Helge Knüttel
 }
 \keyword{package}

--- a/vignettes/getting_fulltext.Rmd
+++ b/vignettes/getting_fulltext.Rmd
@@ -32,8 +32,8 @@ data from more than 1 data source.
 
 ```r
 names(res)
-#> [1] "plos"     "entrez"   "elife"    "pensoft"  "arxiv"    "biorxiv" 
-#> [7] "elsevier" "wiley"
+#> [1] "plos"          "entrez"        "elife"         "pensoft"       "arxiv"        
+#> [6] "biorxiv"       "elsevier"      "sciencedirect" "wiley"  
 ```
 
 Let's dig into the `plos` source object, which is another list, including metadata the 


### PR DESCRIPTION
## Description
I added Elsevier's ScienceDirect API as an additional full text provider. It is available when calling `ft_get` with the appropriate `from` parameter. Formats `xml` (default) and `plain` are available and can be chosen with the `type` parameter.  

It is necessary to have an Elsevier API key for TDM, see the **Authentication** section in R/fulltext-package.R. Availability of full texts behind paywalls depends on actual licenses.

I did not write a test as I don't know how this would work with the need for an API key. Any hints in this direction are welcome.

## Example

To fetch an Open Access article available to everyone (but you still need an API key):
`res <- ft_get("10.1016/j.amsu.2018.10.005", from = "sciencedirect")`
 