### PR TITLE
More detailed documentation for scopus proxy settings 

### DIFF
--- a/R/fulltext-package.R
+++ b/R/fulltext-package.R
@@ -79,8 +79,21 @@
 #' go to a browser and see if you have access to the journal(s) you want. 
 #' If you don't have access in a browser you probably won't have access via 
 #' this package. If you aren't physically at your institution you will likely 
-#' need to be on a VPN or similar so that your IP address is in the range 
+#' need to be on a VPN or similar and eventually require correct proxy settings,
+#' so that your IP address is in the range 
 #' that the two publishers are accepting for that institution.
+#' It might be, that the API access seems to work even while 
+#' in the wrong IP range or have wrong proxy settings, 
+#' but you are not able to see the abstracts, they will be empty.
+#' By using the currect curl options into the calls to ft_search or ft_abstracts even 
+#' the most complex proxy including authentication should work. As an example:
+#' opts=list(key="your-scopus-key")
+#' ft_abstract(x = dois, from = "scopus",
+#' scopusopts = opts,
+#  proxy="http://your-proxy-host-ip",
+#' proxyport=your-proxy-port,
+#' proxyuserpwd="your-proxy-username:your-proxy-password",  # often the same as your windows login
+#' proxyauth=8)  # ntlm - authentication
 #' 
 #' **ScienceDirect**: Elsevier ScienceDirect requires two things: an API key 
 #' and your institution must have access. For the API key, 


### PR DESCRIPTION
Added more details to Scopus  proxy configuration.

There is as well a mistake in the documentation of ft_abstrcact.
It seems to suggest to use it this way:

ft_abstract(....., proxies=proxy(.....)), but this did not work for me.
There are no error messages, it just does not use the proxy settings. 
It only works as I documented in my proposed changes to fulltext-package.R
